### PR TITLE
Sort databases by ID

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,15 +48,7 @@
           ...
         }:
         {
-          packages = {
-            userborn = pkgs.userborn.overrideAttrs {
-              src = lib.sourceFilesBySuffices ./rust/userborn [
-                ".rs"
-                ".toml"
-                ".lock"
-              ];
-              sourceRoot = null;
-            };
+          packages = (import ./nix/packages { inherit pkgs; }) // {
             default = config.packages.userborn;
           };
 

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,0 +1,5 @@
+{ pkgs }:
+
+{
+  userborn = pkgs.callPackage ./userborn.nix { };
+}

--- a/nix/packages/userborn.nix
+++ b/nix/packages/userborn.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  makeBinaryWrapper,
+  mkpasswd,
+}:
+
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ../../rust/userborn/Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  inherit (cargoToml.package) version;
+
+  src = lib.sourceFilesBySuffices ../../rust/userborn [
+    ".rs"
+    ".toml"
+    ".lock"
+  ];
+
+  cargoLock = {
+    lockFile = ../../rust/userborn/Cargo.lock;
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  buildInputs = [ mkpasswd ];
+
+  nativeCheckInputs = [ mkpasswd ];
+
+  postInstall = ''
+    wrapProgram $out/bin/userborn --prefix PATH : ${lib.makeBinPath [ mkpasswd ]}
+  '';
+
+  stripAllList = [ "bin" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nikstur/userborn";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ nikstur ];
+    mainProgram = "userborn";
+  };
+}

--- a/rust/userborn/Cargo.lock
+++ b/rust/userborn/Cargo.lock
@@ -34,12 +34,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
 name = "expect-test"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,22 +41,6 @@ checksum = "9e0be0a561335815e06dab7c62e50353134c796e7a6155402a64bcff66b6a5e0"
 dependencies = [
  "dissimilar",
  "once_cell",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "indexmap"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -175,7 +153,6 @@ dependencies = [
  "anyhow",
  "env_logger",
  "expect-test",
- "indexmap",
  "indoc",
  "log",
  "serde",

--- a/rust/userborn/Cargo.toml
+++ b/rust/userborn/Cargo.toml
@@ -8,7 +8,6 @@ anyhow = "1.0.86"
 log = "0.4.22"
 serde = { version = "1.0.204", features = [ "derive" ] }
 serde_json = "1.0.121"
-indexmap = "2.3.0"
 env_logger = { version = "0.11.5", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This follows the same behaviour as `pwck --sort` from the shadow package. sysusers and update-users-groups.pl do the same.