### PR TITLE
Empty groups that have been removed from the configuration

### DIFF
--- a/rust/userborn/src/group.rs
+++ b/rust/userborn/src/group.rs
@@ -73,6 +73,10 @@ impl Entry {
     pub fn gid(&self) -> u32 {
         self.gid
     }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 /// Split a string containing group members separated by `,` into a list.
@@ -166,6 +170,10 @@ impl Group {
 
     pub fn contains_gid(&self, gid: u32) -> bool {
         self.entries.contains_key(&gid)
+    }
+
+    pub fn entries_mut(&mut self) -> impl IntoIterator<Item = &mut Entry> {
+        self.entries.values_mut()
     }
 }
 


### PR DESCRIPTION
Previously, groups that have been removed from the configuration retain all their prior members, including users that still exist and can observe their membership. This seems undesirable and inconsistent with the behaviour of removed user accounts, which are locked instead. Instead such groups are emptied now. Special care needs to be taken to not accidentally apply this new behaviour to the implicitly created primary group of a user with the same name in case no explicit primary group was specified.