### PR TITLE
fix: set shadow file to root:shadow 0640 in mutable mode

### DIFF
--- a/rust/userborn/src/fs.rs
+++ b/rust/userborn/src/fs.rs
@@ -8,7 +8,12 @@ use anyhow::{Context, Result};
 /// its actual path.
 ///
 /// This increases the atomicity of the write.
-pub fn atomic_write(path: impl AsRef<Path>, buffer: impl AsRef<[u8]>, mode: u32) -> Result<()> {
+pub fn atomic_write(
+    path: impl AsRef<Path>,
+    buffer: impl AsRef<[u8]>,
+    mode: u32,
+    gid: Option<u32>,
+) -> Result<()> {
     let mut i = 0;
 
     let (mut file, tmp_path) = loop {
@@ -39,6 +44,11 @@ pub fn atomic_write(path: impl AsRef<Path>, buffer: impl AsRef<[u8]>, mode: u32)
         .with_context(|| format!("Failed to write to {}", tmp_path.display()))?;
     file.sync_all()
         .with_context(|| format!("Failed to sync the temporary file {}", tmp_path.display()))?;
+
+    if let Some(gid) = gid {
+        std::os::unix::fs::chown(&tmp_path, None, Some(gid))
+            .with_context(|| format!("Failed to set group ownership on {}", tmp_path.display()))?;
+    }
 
     fs::rename(&tmp_path, &path).with_context(|| {
         format!(

--- a/rust/userborn/src/group.rs
+++ b/rust/userborn/src/group.rs
@@ -123,7 +123,7 @@ impl Group {
     }
 
     pub fn to_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer(), 0o644)
+        atomic_write(path, self.to_buffer(), 0o644, None)
     }
 
     pub fn to_buffer(&self) -> String {

--- a/rust/userborn/src/main.rs
+++ b/rust/userborn/src/main.rs
@@ -110,7 +110,9 @@ fn run() -> Result<()> {
     // We should create backup files with an `-` appended to the filename.
     group_db.to_file(group_path)?;
     passwd_db.to_file(passwd_path)?;
-    shadow_db.to_file_sorted(&passwd_db, shadow_path)?;
+
+    let (shadow_mode, shadow_gid) = shadow_file_params(mutable_users, &group_db)?;
+    shadow_db.to_file_sorted(&passwd_db, shadow_path, shadow_mode, shadow_gid)?;
 
     Ok(())
 }
@@ -362,6 +364,20 @@ fn ensure_shadow(user_config: &config::User, shadow_db: &mut Shadow) -> Result<(
         })?;
     }
     Ok(())
+}
+
+fn shadow_file_params(mutable_users: bool, group_db: &Group) -> Result<(u32, Option<u32>)> {
+    if mutable_users {
+        let gid = group_db
+            .get("shadow")
+            .map(group::Entry::gid)
+            .ok_or(anyhow!(
+                "Mutable users require a 'shadow' group but it was not found"
+            ))?;
+        Ok((0o640, Some(gid)))
+    } else {
+        Ok((0o000, None))
+    }
 }
 
 /// Emit warnings for user entries that use weak password hashing schemes.
@@ -759,5 +775,35 @@ mod tests {
         expected_shadow.assert_eq(&shadow_db.to_buffer_sorted(&passwd_db));
 
         Ok(())
+    }
+
+    #[test]
+    fn shadow_file_params_immutable_mode() -> Result<()> {
+        let group_db = Group::default();
+        let (mode, gid) = shadow_file_params(false, &group_db)?;
+        assert_eq!(mode, 0o000);
+        assert_eq!(gid, None);
+        Ok(())
+    }
+
+    #[test]
+    fn shadow_file_params_mutable_mode_with_shadow_group() -> Result<()> {
+        let mut group_db = Group::default();
+        group_db.insert(&group::Entry::new(
+            "shadow".into(),
+            42,
+            BTreeSet::new(),
+        ))?;
+        let (mode, gid) = shadow_file_params(true, &group_db)?;
+        assert_eq!(mode, 0o640);
+        assert_eq!(gid, Some(42));
+        Ok(())
+    }
+
+    #[test]
+    fn shadow_file_params_mutable_mode_without_shadow_group() {
+        let group_db = Group::default();
+        let result = shadow_file_params(true, &group_db);
+        assert!(result.is_err());
     }
 }

--- a/rust/userborn/src/passwd.rs
+++ b/rust/userborn/src/passwd.rs
@@ -169,7 +169,7 @@ impl Passwd {
     }
 
     pub fn to_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer(), 0o644)
+        atomic_write(path, self.to_buffer(), 0o644, None)
     }
 
     pub fn to_buffer(&self) -> String {

--- a/rust/userborn/src/shadow.rs
+++ b/rust/userborn/src/shadow.rs
@@ -131,8 +131,14 @@ impl Shadow {
     /// Write the shadow database to a file.
     ///
     /// Sort the entries by their UIDs in the passwd database.
-    pub fn to_file_sorted(&self, passwd: &Passwd, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer_sorted(passwd), 0o000)
+    pub fn to_file_sorted(
+        &self,
+        passwd: &Passwd,
+        path: impl AsRef<Path>,
+        mode: u32,
+        gid: Option<u32>,
+    ) -> Result<()> {
+        atomic_write(path, self.to_buffer_sorted(passwd), mode, gid)
     }
 
     /// Write the shadow database to a string buffer.


### PR DESCRIPTION
When mutable users are enabled, tools like passwd need to read /etc/shadow, which requires the file to be accessible to the shadow group.

In mutable mode, set the shadow file to mode 0640 with the shadow group.

In immutable mode the existing 0000 behavior is preserved.