### PR TITLE
Write /etc/shadow as 0640 root:shadow when the group exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Groups that were removed from the config are now emptied (all their users are
   removed from it). This makes the behaviour consistent with the way we treat
   users. They're never removed (to avoid GID re-use) but effectively disabled.
+- `/etc/shadow` is now written `0640 root:shadow` when a `shadow` group is
+  present in the config (otherwise `0000` as before). This matches NixOS's
+  `update-users-groups.pl` and Debian, and lets `unix_chkpwd(8)` run setgid
+  `shadow` instead of setuid root.
 - Mutable users are now fully supported. Previously, Userborn would disable
   all users and drain all groups that were not in it's current config. Now, if
   mutable users are enabled via `USERBORN_MUTABLE_USERS`, only users/groups

--- a/rust/userborn/src/fs.rs
+++ b/rust/userborn/src/fs.rs
@@ -1,4 +1,9 @@
-use std::{fs, io::Write, os::unix::fs::OpenOptionsExt, path::Path};
+use std::{
+    fs,
+    io::Write,
+    os::unix::fs::{chown, OpenOptionsExt},
+    path::Path,
+};
 
 use anyhow::{Context, Result};
 
@@ -8,7 +13,15 @@ use anyhow::{Context, Result};
 /// its actual path.
 ///
 /// This increases the atomicity of the write.
-pub fn atomic_write(path: impl AsRef<Path>, buffer: impl AsRef<[u8]>, mode: u32) -> Result<()> {
+///
+/// If `gid` is set, the temporary file is `chown`ed to that group before the rename so the
+/// final path never appears with a different group than requested.
+pub fn atomic_write(
+    path: impl AsRef<Path>,
+    buffer: impl AsRef<[u8]>,
+    mode: u32,
+    gid: Option<u32>,
+) -> Result<()> {
     let mut i = 0;
 
     let (mut file, tmp_path) = loop {
@@ -39,6 +52,11 @@ pub fn atomic_write(path: impl AsRef<Path>, buffer: impl AsRef<[u8]>, mode: u32)
         .with_context(|| format!("Failed to write to {}", tmp_path.display()))?;
     file.sync_all()
         .with_context(|| format!("Failed to sync the temporary file {}", tmp_path.display()))?;
+
+    if let Some(gid) = gid {
+        chown(&tmp_path, None, Some(gid))
+            .with_context(|| format!("Failed to chown {} to gid {gid}", tmp_path.display()))?;
+    }
 
     fs::rename(&tmp_path, &path).with_context(|| {
         format!(

--- a/rust/userborn/src/group.rs
+++ b/rust/userborn/src/group.rs
@@ -123,7 +123,7 @@ impl Group {
     }
 
     pub fn to_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer(), 0o644)
+        atomic_write(path, self.to_buffer(), 0o644, None)
     }
 
     pub fn to_buffer(&self) -> String {

--- a/rust/userborn/src/main.rs
+++ b/rust/userborn/src/main.rs
@@ -105,12 +105,16 @@ fn run() -> Result<()> {
 
     warn_about_weak_password_hashes(&shadow_db);
 
+    // Resolve the `shadow` group from the database we just built so the lookup is independent of
+    // the host's NSS configuration and works on first boot before /etc/group exists.
+    let shadow_gid = group_db.get("shadow").map(group::Entry::gid);
+
     log::debug!("Persisting files to disk...");
     // We should skip this if the files haven't actually changed
     // We should create backup files with an `-` appended to the filename.
     group_db.to_file(group_path)?;
     passwd_db.to_file(passwd_path)?;
-    shadow_db.to_file_sorted(&passwd_db, shadow_path)?;
+    shadow_db.to_file_sorted(&passwd_db, shadow_path, shadow_gid)?;
 
     Ok(())
 }

--- a/rust/userborn/src/passwd.rs
+++ b/rust/userborn/src/passwd.rs
@@ -169,7 +169,7 @@ impl Passwd {
     }
 
     pub fn to_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer(), 0o644)
+        atomic_write(path, self.to_buffer(), 0o644, None)
     }
 
     pub fn to_buffer(&self) -> String {

--- a/rust/userborn/src/shadow.rs
+++ b/rust/userborn/src/shadow.rs
@@ -131,8 +131,18 @@ impl Shadow {
     /// Write the shadow database to a file.
     ///
     /// Sort the entries by their UIDs in the passwd database.
-    pub fn to_file_sorted(&self, passwd: &Passwd, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer_sorted(passwd), 0o000)
+    ///
+    /// When a `shadow` group exists, the file is written `0o640` owned by that group so a
+    /// setgid-`shadow` `unix_chkpwd(8)` can read it. Otherwise it falls back to `0o000`, readable
+    /// only via `CAP_DAC_OVERRIDE`.
+    pub fn to_file_sorted(
+        &self,
+        passwd: &Passwd,
+        path: impl AsRef<Path>,
+        shadow_gid: Option<u32>,
+    ) -> Result<()> {
+        let mode = if shadow_gid.is_some() { 0o640 } else { 0o000 };
+        atomic_write(path, self.to_buffer_sorted(passwd), mode, shadow_gid)
     }
 
     /// Write the shadow database to a string buffer.


### PR DESCRIPTION
Alternative to #41 

userborn currently writes `/etc/shadow` as mode `0000`, readable only via `CAP_DAC_OVERRIDE`.
That forces `unix_chkpwd`, the helper `pam_unix` spawns when a non-root process (screen lockers, polkit auth dialogs) needs to verify a password, to be installed setuid root.

Distros are split on this:

```
Debian/Ubuntu      0640 root:shadow   unix_chkpwd setgid shadow
NixOS (perl path)  0640 root:shadow   unix_chkpwd setuid root
Arch               0600 root:root     unix_chkpwd setuid root
Fedora             0000 root:root     unix_chkpwd setuid root
systemd-sysusers   0000 on first create, otherwise preserves existing
```

userborn is meant to be a drop-in for NixOS's `update-users-groups.pl`, which has written `root:shadow 0640` since 2016 (NixOS/nixpkgs@fedd7cd).
The current `0000` is therefore a behavioural change.

The trade-off between the two models is:

**`0000 root:root` + setuid-root `unix_chkpwd`**
A code-exec bug in `unix_chkpwd` gives full root.
Wrong configuration of the `shadow` group does not grant access to the shadow file.

**`0640 root:shadow` + setgid-`shadow` `unix_chkpwd`**
A code-exec bug in `unix_chkpwd` yields gid `shadow` only: the attacker can read `/etc/shadow` and brute-force hashes offline, but cannot `setuid`, cannot write anything.
The trade-off is that gid `shadow` becomes a meaningful boundary that must be kept empty.
We can do so on NixOS using an assertion.

The Debian model trades a misconfiguration risk (something gaining gid `shadow`) that can leak password hashes for removing a root-equivalent setuid binary from the default install that could lead to code-exec as root.

This change enables but does not force the setgid model: if the config defines a `shadow` group (NixOS always does), `/etc/shadow` is written as `0640` owned by the `shadow` group.
If not, the previous `0000` behaviour is kept.
The gid is resolved from the in-memory group database userborn just built, so it works on first boot before `/etc/group` exists and is independent of host NSS.
The `chown` happens on the temp file before the atomic rename, so the final path never appears with a stale group.

References:
- Debian shadowconfig: https://salsa.debian.org/debian/shadow/-/blob/master/debian/shadowconfig
- Debian pam (sgid shadow on `unix_chkpwd`): https://salsa.debian.org/vorlon/pam/-/blob/master/debian/rules
- NixOS `update-users-groups.pl`: [`nixos/modules/config/update-users-groups.pl:317-322`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/update-users-groups.pl#L317-L322)
