### PR TITLE
Manage /etc/subuid and /etc/subgid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   same permissions as before. This enables setups where `/etc/shadow` is owned
   by the `shadow` group with mode `640` and `unix_chkpwd` only has the `setgid`
   bit. Most notably, this is the default on Debian/Ubuntu derivatives.
+- Userborn now manages `/etc/subuid` and `/etc/subgid`. Per-user explicit
+  ranges (`subUidRanges`, `subGidRanges`) are written verbatim, and
+  `autoSubIdRange` allocates a stable, non-overlapping range that is
+  preserved across generations. Like UIDs and GIDs, existing subordinate id
+  entries are never removed so a range cannot be reassigned to a different
+  owner. Cross-owner overlap is logged as a warning, or refused outright
+  when `strictSubIdOverlap` is set in the config.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@
   `autoSubIdRange` allocates a stable, non-overlapping range that is
   preserved across generations. Like UIDs and GIDs, existing subordinate id
   entries are never removed so a range cannot be reassigned to a different
-  owner. Cross-owner overlap is logged as a warning, or refused outright
-  when `strictSubIdOverlap` is set in the config.
+  owner. Cross-owner overlap is refused outright.
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -161,9 +161,8 @@ Per user you can either:
 
 - list explicit ranges via `subUidRanges` / `subGidRanges`, which are written
   verbatim, or
-- set `autoSubIdRange: true` to have Userborn allocate a single
-  `subIdAutoCount`-wide range (default 65536) at or above `subIdAutoBase`
-  (default 100000) that does not overlap any other owner's ranges.
+- set `autoSubIdRange: true` to have Userborn allocate a single 65536-wide
+  range at or above 100000 that does not overlap any other owner's ranges.
 
 Auto-allocated ranges are stable: once written they are read back from
 `/etc/sub{u,g}id` on subsequent runs and never moved, even if other ranges
@@ -172,8 +171,8 @@ config are kept so the range cannot be reused by a different owner.
 
 If the resulting set of ranges overlaps across distinct owners (which can
 only happen via explicit configuration or pre-existing on-disk state),
-Userborn logs a warning. Set `strictSubIdOverlap: true` at the top level of
-the config to turn this into a hard error so an overlap never reaches disk.
+Userborn refuses to write `/etc/sub{u,g}id` and exits with an error. The
+other databases (`passwd`, `group`, `shadow`) are still written.
 
 ## Replacing `system.activationScripts`
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Declaratively bear (manage) Linux users and groups.
 - Simple JSON config format.
 - Create per-user groups if no explicit primary group is provided.
 - Warn about insecure password hashing schemes.
+- Manage `/etc/subuid` and `/etc/subgid` for rootless containers.
 
 ### Where does it run?
 
@@ -33,6 +34,9 @@ services.userborn.enable = true;
 - Never deletes a user or group, only disables them when they are not present
   in the config anymore.
 - Never changes the UID of an existing user or the GID of an existing group.
+- Never removes a subordinate UID/GID range from `/etc/sub{u,g}id` for an
+  owner that no longer requests one, so the range cannot be reassigned to a
+  different owner.
 - The file mode, uid, and gid of the `/etc/{group,passwd,shadow}` files is
   never changed. If the files already exist before Userborn runs for the first
   time it will retain these values.
@@ -146,7 +150,30 @@ Userborn:
 ### Limitations
 
 - Currently doesn't support group passwords (and thus also doesn't support `/etc/gshadow`).
-- Doesn't handle SUBUID/SUBGIDs.
+
+## Subordinate UID/GID Ranges
+
+Userborn writes `/etc/subuid` and `/etc/subgid` so that tools like
+`newuidmap`/`newgidmap` (used by rootless Podman, Docker, and similar) work
+out of the box.
+
+Per user you can either:
+
+- list explicit ranges via `subUidRanges` / `subGidRanges`, which are written
+  verbatim, or
+- set `autoSubIdRange: true` to have Userborn allocate a single
+  `subIdAutoCount`-wide range (default 65536) at or above `subIdAutoBase`
+  (default 100000) that does not overlap any other owner's ranges.
+
+Auto-allocated ranges are stable: once written they are read back from
+`/etc/sub{u,g}id` on subsequent runs and never moved, even if other ranges
+change around them. As with UIDs, entries for owners that disappear from the
+config are kept so the range cannot be reused by a different owner.
+
+If the resulting set of ranges overlaps across distinct owners (which can
+only happen via explicit configuration or pre-existing on-disk state),
+Userborn logs a warning. Set `strictSubIdOverlap: true` at the top level of
+the config to turn this into a hard error so an overlap never reaches disk.
 
 ## Replacing `system.activationScripts`
 

--- a/rust/userborn/src/config.rs
+++ b/rust/userborn/src/config.rs
@@ -9,21 +9,6 @@ use serde::Deserialize;
 
 use crate::subid;
 
-#[derive(Deserialize, Debug, Clone, Copy)]
-pub struct SubIdRange {
-    pub start: u64,
-    pub count: u64,
-}
-
-impl From<SubIdRange> for subid::Range {
-    fn from(r: SubIdRange) -> Self {
-        Self {
-            start: r.start,
-            count: r.count,
-        }
-    }
-}
-
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
@@ -49,10 +34,10 @@ pub struct User {
     pub auto_sub_id_range: bool,
     /// Explicit subordinate UID ranges for this user.
     #[serde(default)]
-    pub sub_uid_ranges: Vec<SubIdRange>,
+    pub sub_uid_ranges: Vec<subid::Range>,
     /// Explicit subordinate GID ranges for this user.
     #[serde(default)]
-    pub sub_gid_ranges: Vec<SubIdRange>,
+    pub sub_gid_ranges: Vec<subid::Range>,
     #[serde(flatten)]
     pub password: Password,
 }
@@ -94,24 +79,6 @@ pub struct Config {
     pub users: Vec<User>,
     #[serde(default)]
     pub groups: Vec<Group>,
-    /// Lowest id at which automatically allocated subordinate id ranges start.
-    #[serde(default = "default_sub_id_base")]
-    pub sub_id_auto_base: u64,
-    /// Width of an automatically allocated subordinate id range.
-    #[serde(default = "default_sub_id_count")]
-    pub sub_id_auto_count: u64,
-    /// Refuse to write `/etc/sub{u,g}id` when ranges overlap across owners instead of merely
-    /// warning.
-    #[serde(default)]
-    pub strict_sub_id_overlap: bool,
-}
-
-fn default_sub_id_base() -> u64 {
-    100_000
-}
-
-fn default_sub_id_count() -> u64 {
-    65_536
 }
 
 impl Config {

--- a/rust/userborn/src/config.rs
+++ b/rust/userborn/src/config.rs
@@ -7,6 +7,23 @@ use std::{
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use crate::subid;
+
+#[derive(Deserialize, Debug, Clone, Copy)]
+pub struct SubIdRange {
+    pub start: u64,
+    pub count: u64,
+}
+
+impl From<SubIdRange> for subid::Range {
+    fn from(r: SubIdRange) -> Self {
+        Self {
+            start: r.start,
+            count: r.count,
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
@@ -27,8 +44,23 @@ pub struct User {
     pub home: Option<String>,
     /// The shell of the user
     pub shell: Option<String>,
+    /// Whether to automatically allocate a subordinate UID/GID range for this user.
+    #[serde(default)]
+    pub auto_sub_id_range: bool,
+    /// Explicit subordinate UID ranges for this user.
+    #[serde(default)]
+    pub sub_uid_ranges: Vec<SubIdRange>,
+    /// Explicit subordinate GID ranges for this user.
+    #[serde(default)]
+    pub sub_gid_ranges: Vec<SubIdRange>,
     #[serde(flatten)]
     pub password: Password,
+}
+
+impl User {
+    pub fn has_sub_id_config(&self) -> bool {
+        self.auto_sub_id_range || !self.sub_uid_ranges.is_empty() || !self.sub_gid_ranges.is_empty()
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -56,11 +88,30 @@ pub struct Group {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(default)]
     pub users: Vec<User>,
     #[serde(default)]
     pub groups: Vec<Group>,
+    /// Lowest id at which automatically allocated subordinate id ranges start.
+    #[serde(default = "default_sub_id_base")]
+    pub sub_id_auto_base: u64,
+    /// Width of an automatically allocated subordinate id range.
+    #[serde(default = "default_sub_id_count")]
+    pub sub_id_auto_count: u64,
+    /// Refuse to write `/etc/sub{u,g}id` when ranges overlap across owners instead of merely
+    /// warning.
+    #[serde(default)]
+    pub strict_sub_id_overlap: bool,
+}
+
+fn default_sub_id_base() -> u64 {
+    100_000
+}
+
+fn default_sub_id_count() -> u64 {
+    65_536
 }
 
 impl Config {
@@ -102,7 +153,13 @@ mod tests {
                 },
                 {
                     "name": "barebones",
-                }
+                },
+                {
+                    "isNormal": true,
+                    "name": "hassubids",
+                    "autoSubIdRange": true,
+                    "subUidRanges": [ { "start": 200_000, "count": 131_072 } ],
+                },
             ],
             "groups": [
                 {

--- a/rust/userborn/src/main.rs
+++ b/rust/userborn/src/main.rs
@@ -132,7 +132,10 @@ fn run() -> Result<()> {
 
     warn_about_weak_password_hashes(&shadow_db);
 
-    update_subids(&config, &mut sub_ids)?;
+    // Compute subids in memory but hold any error until after passwd/group/shadow are on
+    // disk, so a bad subid config or pre-existing overlap cannot block user/group
+    // reconciliation.
+    let subid_result = update_subids(&config, &mut sub_ids);
 
     log::debug!("Persisting files to disk...");
     // We should skip this if the files haven't actually changed
@@ -144,6 +147,8 @@ fn run() -> Result<()> {
         shadow_db.to_buffer_sorted(&passwd_db),
         &shadow_rights,
     )?;
+
+    subid_result.context("Refusing to write /etc/subuid and /etc/subgid")?;
     atomic_write(subuid_path, sub_ids.uid.to_buffer(), &subid_rights.0)?;
     atomic_write(subgid_path, sub_ids.gid.to_buffer(), &subid_rights.1)?;
 
@@ -163,23 +168,13 @@ fn update_subids(config: &Config, sub_ids: &mut SubIds) -> Result<()> {
     // any subid config are skipped so their existing on-disk entries are preserved verbatim.
     let mut needs_auto: Vec<&str> = Vec::new();
     for user in config.users.iter().filter(|u| u.has_sub_id_config()) {
-        let mut uranges: Vec<_> = user
-            .sub_uid_ranges
-            .iter()
-            .copied()
-            .map(Into::into)
-            .collect();
-        let mut granges: Vec<_> = user
-            .sub_gid_ranges
-            .iter()
-            .copied()
-            .map(Into::into)
-            .collect();
+        let mut uranges = user.sub_uid_ranges.clone();
+        let mut granges = user.sub_gid_ranges.clone();
 
         // Auto ranges are mirrored to both files (see `SubIds::auto_range`).
         // Only the explicit ranges above are per-file.
         if user.auto_sub_id_range {
-            if let Some(existing) = sub_ids.auto_range(&user.name, config.sub_id_auto_count) {
+            if let Some(existing) = sub_ids.auto_range(&user.name) {
                 uranges.push(existing);
                 granges.push(existing);
             } else {
@@ -202,10 +197,8 @@ fn update_subids(config: &Config, sub_ids: &mut SubIds) -> Result<()> {
             .collect();
         occupied.sort_by_key(|r| r.start);
 
-        let range = subid::allocate(config.sub_id_auto_base, config.sub_id_auto_count, &occupied)
-            .with_context(|| {
-            format!("Failed to allocate auto subordinate id range for {name}")
-        })?;
+        let range = subid::allocate(subid::AUTO_BASE, subid::AUTO_COUNT, &occupied)
+            .with_context(|| format!("Failed to allocate auto subordinate id range for {name}"))?;
         log::info!(
             "Allocated subordinate id range {} (count {}) for user {name}.",
             range.start,
@@ -219,30 +212,33 @@ fn update_subids(config: &Config, sub_ids: &mut SubIds) -> Result<()> {
         }
     }
 
-    check_subid_overlap("subuid", &sub_ids.uid, config.strict_sub_id_overlap)?;
-    check_subid_overlap("subgid", &sub_ids.gid, config.strict_sub_id_overlap)?;
+    check_subid_overlap("subuid", &sub_ids.uid)?;
+    check_subid_overlap("subgid", &sub_ids.gid)?;
 
     Ok(())
 }
 
-/// Report subordinate id ranges that overlap across distinct owners.
+/// Reject subordinate id ranges that overlap across distinct owners.
 ///
 /// The auto allocator never produces overlaps, so any overlap comes from explicit config or
-/// pre-existing on-disk state. By default this only warns, since refusing to write would
-/// leave the file absent or stale. With `strict` it becomes a hard error and the previous
-/// file contents are left untouched.
-fn check_subid_overlap(what: &str, db: &SubId, strict: bool) -> Result<()> {
+/// pre-existing on-disk state. Either way it would let one user's unprivileged containers
+/// access another's files, so it is treated as a hard error and the previous file contents
+/// are left untouched.
+fn check_subid_overlap(what: &str, db: &SubId) -> Result<()> {
     let entries: Vec<_> = db.entries().collect();
     if let Some((a, b)) = subid::find_overlap(&entries) {
-        let msg = format!(
+        bail!(
             "{what}: range {}:{}:{} overlaps {}:{}:{}. \
-             One user's unprivileged containers may access the other's",
-            a.name, a.range.start, a.range.count, b.name, b.range.start, b.range.count,
+             One user's unprivileged containers may access the other's. \
+             Fix the explicit subUidRanges/subGidRanges in your config or \
+             edit /etc/{what} manually",
+            a.name,
+            a.range.start,
+            a.range.count,
+            b.name,
+            b.range.start,
+            b.range.count,
         );
-        if strict {
-            bail!("{msg}");
-        }
-        log::warn!("{msg}.");
     }
     Ok(())
 }
@@ -915,10 +911,8 @@ mod tests {
         expected.assert_eq(&sub_ids.uid.to_buffer());
         expected.assert_eq(&sub_ids.gid.to_buffer());
 
-        // GEN 1: bob is added with auto, and an explicit user whose range
-        // collides with alice's auto base. bob's auto range slots into the
-        // gap between alice and root. The alice/explicit collision must be
-        // reported but not fail in non-strict mode.
+        // GEN 1: bob is added with auto and slots into the gap between alice
+        // and root. An explicit subuid-only range is also added.
         let gen1: Config = serde_json::from_value(serde_json::json!({
             "users": [
                 {
@@ -930,7 +924,8 @@ mod tests {
                 { "isNormal": true, "name": "bob", "autoSubIdRange": true },
                 {
                     "isNormal": true, "name": "explicit",
-                    "subUidRanges": [ { "start": 100_000, "count": 1000 } ],
+                    "subUidRanges": [ { "start": 300_000, "count": 1000 } ],
+                    "subGidRanges": [ { "start": 300_000, "count": 1000 } ],
                 },
             ],
         }))?;
@@ -938,17 +933,12 @@ mod tests {
 
         let expected = expect![[r"
             alice:100000:65536
-            explicit:100000:1000
             bob:165536:65536
+            explicit:300000:1000
             root:1000000:1000000000
         "]];
         expected.assert_eq(&sub_ids.uid.to_buffer());
-        expect![[r"
-            alice:100000:65536
-            bob:165536:65536
-            root:1000000:1000000000
-        "]]
-        .assert_eq(&sub_ids.gid.to_buffer());
+        expected.assert_eq(&sub_ids.gid.to_buffer());
 
         // GEN 2: alice and explicit are dropped from the config but their
         // ranges must be kept on disk. Re-applying GEN 1 afterwards must
@@ -961,21 +951,23 @@ mod tests {
         }))?;
         update_subids(&gen2, &mut sub_ids)?;
         expected.assert_eq(&sub_ids.uid.to_buffer());
+        expected.assert_eq(&sub_ids.gid.to_buffer());
 
         update_subids(&gen1, &mut sub_ids)?;
         expected.assert_eq(&sub_ids.uid.to_buffer());
-        expect![[r"
-            alice:100000:65536
-            bob:165536:65536
-            root:1000000:1000000000
-        "]]
-        .assert_eq(&sub_ids.gid.to_buffer());
+        expected.assert_eq(&sub_ids.gid.to_buffer());
 
-        // Strict mode: the alice/explicit overlap must now fail before
-        // anything is written.
-        let mut gen1_strict = gen1.clone();
-        gen1_strict.strict_sub_id_overlap = true;
-        assert!(update_subids(&gen1_strict, &mut sub_ids).is_err());
+        // An explicit range that overlaps another owner's range is rejected.
+        let bad: Config = serde_json::from_value(serde_json::json!({
+            "users": [
+                { "isNormal": true, "name": "alice", "autoSubIdRange": true },
+                {
+                    "isNormal": true, "name": "clash",
+                    "subUidRanges": [ { "start": 100_000, "count": 1000 } ],
+                },
+            ],
+        }))?;
+        assert!(update_subids(&bad, &mut sub_ids).is_err());
 
         Ok(())
     }

--- a/rust/userborn/src/main.rs
+++ b/rust/userborn/src/main.rs
@@ -5,10 +5,11 @@ mod id;
 mod passwd;
 mod password;
 mod shadow;
+mod subid;
 
 use std::{collections::BTreeSet, io::Write, path::Path, process::ExitCode};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use log::{Level, LevelFilter};
 
 use config::Config;
@@ -17,6 +18,7 @@ use group::Group;
 use passwd::Passwd;
 use password::HashedPassword;
 use shadow::Shadow;
+use subid::{SubId, SubIds};
 
 trait FromBuffer {
     fn from_buffer(buf: &str) -> Self;
@@ -108,10 +110,17 @@ fn run() -> Result<()> {
     let group_path = format!("{directory}/group");
     let passwd_path = format!("{directory}/passwd");
     let shadow_path = format!("{directory}/shadow");
+    let subuid_path = format!("{directory}/subuid");
+    let subgid_path = format!("{directory}/subgid");
 
     let (mut group_db, group_rights) = read_or_default::<Group>(&group_path, 0o644);
     let (mut passwd_db, passwd_rights) = read_or_default::<Passwd>(&passwd_path, 0o644);
     let (mut shadow_db, shadow_rights) = read_or_default::<Shadow>(&shadow_path, 0o000);
+    let (mut sub_ids, subid_rights) = {
+        let (uid, ur) = read_or_default::<SubId>(&subuid_path, 0o644);
+        let (gid, gr) = read_or_default::<SubId>(&subgid_path, 0o644);
+        (SubIds { uid, gid }, (ur, gr))
+    };
 
     update_users_and_groups(
         &config,
@@ -123,6 +132,8 @@ fn run() -> Result<()> {
 
     warn_about_weak_password_hashes(&shadow_db);
 
+    update_subids(&config, &mut sub_ids)?;
+
     log::debug!("Persisting files to disk...");
     // We should skip this if the files haven't actually changed
     // We should create backup files with an `-` appended to the filename.
@@ -133,7 +144,106 @@ fn run() -> Result<()> {
         shadow_db.to_buffer_sorted(&passwd_db),
         &shadow_rights,
     )?;
+    atomic_write(subuid_path, sub_ids.uid.to_buffer(), &subid_rights.0)?;
+    atomic_write(subgid_path, sub_ids.gid.to_buffer(), &subid_rights.1)?;
 
+    Ok(())
+}
+
+/// Reconcile `/etc/sub{u,g}id` with the declared config.
+///
+/// Explicit ranges are written verbatim. For users with `auto_sub_id_range` set, an existing
+/// auto-style range is carried over, otherwise a fresh non-overlapping one is allocated.
+///
+/// Entries for owners not in the config are kept so that subordinate id ranges can never be
+/// reassigned to a different owner.
+fn update_subids(config: &Config, sub_ids: &mut SubIds) -> Result<()> {
+    // First pass: lay down all explicit ranges and carry over existing auto ranges, so the
+    // second pass can allocate new auto ranges against the complete picture. Users without
+    // any subid config are skipped so their existing on-disk entries are preserved verbatim.
+    let mut needs_auto: Vec<&str> = Vec::new();
+    for user in config.users.iter().filter(|u| u.has_sub_id_config()) {
+        let mut uranges: Vec<_> = user
+            .sub_uid_ranges
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect();
+        let mut granges: Vec<_> = user
+            .sub_gid_ranges
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect();
+
+        // Auto ranges are mirrored to both files (see `SubIds::auto_range`).
+        // Only the explicit ranges above are per-file.
+        if user.auto_sub_id_range {
+            if let Some(existing) = sub_ids.auto_range(&user.name, config.sub_id_auto_count) {
+                uranges.push(existing);
+                granges.push(existing);
+            } else {
+                needs_auto.push(&user.name);
+            }
+        }
+
+        sub_ids.uid.set(&user.name, uranges);
+        sub_ids.gid.set(&user.name, granges);
+    }
+
+    // Second pass: allocate fresh auto ranges in config order.
+    // allocate() tolerates the duplicates from chaining both files.
+    for name in needs_auto {
+        let mut occupied: Vec<_> = sub_ids
+            .uid
+            .entries()
+            .chain(sub_ids.gid.entries())
+            .map(|e| e.range)
+            .collect();
+        occupied.sort_by_key(|r| r.start);
+
+        let range = subid::allocate(config.sub_id_auto_base, config.sub_id_auto_count, &occupied)
+            .with_context(|| {
+            format!("Failed to allocate auto subordinate id range for {name}")
+        })?;
+        log::info!(
+            "Allocated subordinate id range {} (count {}) for user {name}.",
+            range.start,
+            range.count,
+        );
+
+        for db in [&mut sub_ids.uid, &mut sub_ids.gid] {
+            let mut v = db.ranges(name).to_vec();
+            v.push(range);
+            db.set(name, v);
+        }
+    }
+
+    check_subid_overlap("subuid", &sub_ids.uid, config.strict_sub_id_overlap)?;
+    check_subid_overlap("subgid", &sub_ids.gid, config.strict_sub_id_overlap)?;
+
+    Ok(())
+}
+
+/// Report subordinate id ranges that overlap across distinct owners.
+///
+/// The auto allocator never produces overlaps, so any overlap comes from explicit config or
+/// pre-existing on-disk state. By default this only warns, since refusing to write would
+/// leave the file absent or stale. With `strict` it becomes a hard error and the previous
+/// file contents are left untouched.
+fn check_subid_overlap(what: &str, db: &SubId, strict: bool) -> Result<()> {
+    let entries: Vec<_> = db.entries().collect();
+    if let Some((a, b)) = subid::find_overlap(&entries) {
+        let msg = format!(
+            "{what}: range {}:{}:{} overlaps {}:{}:{}. \
+             One user's unprivileged containers may access the other's",
+            a.name, a.range.start, a.range.count, b.name, b.range.start, b.range.count,
+        );
+        if strict {
+            bail!("{msg}");
+        }
+        log::warn!("{msg}.");
+    }
     Ok(())
 }
 
@@ -776,6 +886,96 @@ mod tests {
             normalo:$y$j9T$CZSAJTLCfrBvcCgvOTY4W1$G7uzyX3O6K.DR8KJLL/oL.8EREPSRTIjBn76SpvcH4A:1::::::
         "#]];
         expected_shadow.assert_eq(&shadow_db.to_buffer_sorted(&passwd_db));
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_subids_across_generations() -> Result<()> {
+        let mut sub_ids = SubIds::default();
+
+        // GEN 0: alice (auto) and root with the huge incus-style range.
+        // alice's auto range must be allocated below the root range.
+        let gen0: Config = serde_json::from_value(serde_json::json!({
+            "users": [
+                {
+                    "name": "root", "uid": 0,
+                    "subUidRanges": [ { "start": 1_000_000, "count": 1_000_000_000 } ],
+                    "subGidRanges": [ { "start": 1_000_000, "count": 1_000_000_000 } ],
+                },
+                { "isNormal": true, "name": "alice", "autoSubIdRange": true },
+            ],
+        }))?;
+        update_subids(&gen0, &mut sub_ids)?;
+
+        let expected = expect![[r"
+            alice:100000:65536
+            root:1000000:1000000000
+        "]];
+        expected.assert_eq(&sub_ids.uid.to_buffer());
+        expected.assert_eq(&sub_ids.gid.to_buffer());
+
+        // GEN 1: bob is added with auto, and an explicit user whose range
+        // collides with alice's auto base. bob's auto range slots into the
+        // gap between alice and root. The alice/explicit collision must be
+        // reported but not fail in non-strict mode.
+        let gen1: Config = serde_json::from_value(serde_json::json!({
+            "users": [
+                {
+                    "name": "root", "uid": 0,
+                    "subUidRanges": [ { "start": 1_000_000, "count": 1_000_000_000 } ],
+                    "subGidRanges": [ { "start": 1_000_000, "count": 1_000_000_000 } ],
+                },
+                { "isNormal": true, "name": "alice", "autoSubIdRange": true },
+                { "isNormal": true, "name": "bob", "autoSubIdRange": true },
+                {
+                    "isNormal": true, "name": "explicit",
+                    "subUidRanges": [ { "start": 100_000, "count": 1000 } ],
+                },
+            ],
+        }))?;
+        update_subids(&gen1, &mut sub_ids)?;
+
+        let expected = expect![[r"
+            alice:100000:65536
+            explicit:100000:1000
+            bob:165536:65536
+            root:1000000:1000000000
+        "]];
+        expected.assert_eq(&sub_ids.uid.to_buffer());
+        expect![[r"
+            alice:100000:65536
+            bob:165536:65536
+            root:1000000:1000000000
+        "]]
+        .assert_eq(&sub_ids.gid.to_buffer());
+
+        // GEN 2: alice and explicit are dropped from the config but their
+        // ranges must be kept on disk. Re-applying GEN 1 afterwards must
+        // reproduce the GEN 1 state byte-for-byte.
+        let gen2: Config = serde_json::from_value(serde_json::json!({
+            "users": [
+                { "name": "root", "uid": 0 },
+                { "isNormal": true, "name": "bob", "autoSubIdRange": true },
+            ],
+        }))?;
+        update_subids(&gen2, &mut sub_ids)?;
+        expected.assert_eq(&sub_ids.uid.to_buffer());
+
+        update_subids(&gen1, &mut sub_ids)?;
+        expected.assert_eq(&sub_ids.uid.to_buffer());
+        expect![[r"
+            alice:100000:65536
+            bob:165536:65536
+            root:1000000:1000000000
+        "]]
+        .assert_eq(&sub_ids.gid.to_buffer());
+
+        // Strict mode: the alice/explicit overlap must now fail before
+        // anything is written.
+        let mut gen1_strict = gen1.clone();
+        gen1_strict.strict_sub_id_overlap = true;
+        assert!(update_subids(&gen1_strict, &mut sub_ids).is_err());
 
         Ok(())
     }

--- a/rust/userborn/src/subid.rs
+++ b/rust/userborn/src/subid.rs
@@ -1,0 +1,295 @@
+use std::{collections::BTreeMap, fmt::Write as _};
+
+use anyhow::{Result, bail};
+
+use crate::FromBuffer;
+
+/// 31-bit ceiling on the subordinate id space.
+///
+/// Per <https://systemd.io/UIDS-GIDS/> ids above this are liable to hit signedness bugs in
+/// various userspace tools, so the auto allocator never hands out a range that extends past it.
+const SUBID_MAX: u64 = 0x8000_0000;
+
+/// A half-open subordinate id interval `[start, start + count)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Range {
+    pub start: u64,
+    pub count: u64,
+}
+
+impl Range {
+    fn end(self) -> u64 {
+        self.start.saturating_add(self.count)
+    }
+
+    /// Two half-open intervals overlap iff each one's start lies strictly before the other's
+    /// end.
+    fn overlaps(self, other: Range) -> bool {
+        self.start < other.end() && other.start < self.end()
+    }
+}
+
+/// Borrowed view of a `sub{u,g}id` line: owner name plus range.
+#[derive(Debug, Clone, Copy)]
+pub struct EntryRef<'a> {
+    /// Owner name, or a numeric uid rendered as a string (both valid per `subuid(5)`).
+    pub name: &'a str,
+    pub range: Range,
+}
+
+fn parse_line(line: &str) -> Option<(&str, Range)> {
+    if line.starts_with('#') {
+        return None;
+    }
+    let mut fields = line.splitn(3, ':');
+    let name = fields.next()?;
+    let range = Range {
+        start: fields.next()?.parse().ok()?,
+        count: fields.next()?.parse().ok()?,
+    };
+    Some((name, range))
+}
+
+/// The pair of subordinate id databases (`/etc/subuid` and `/etc/subgid`).
+#[derive(Default)]
+pub struct SubIds {
+    pub uid: SubId,
+    pub gid: SubId,
+}
+
+impl SubIds {
+    /// Find an existing auto-allocated range for `name`.
+    ///
+    /// Auto ranges are written identically to both files, matching `usermod --add-subuids
+    /// --add-subgids`. Looking in both lets us restore a range that survived in only one
+    /// file instead of allocating a fresh one and breaking existing containers. If both are
+    /// present but disagree we warn and prefer `subuid`.
+    pub fn auto_range(&self, name: &str, count: u64) -> Option<Range> {
+        let u = self.uid.auto_range(name, count);
+        let g = self.gid.auto_range(name, count);
+        if u.is_some() && g.is_some() && u != g {
+            log::warn!(
+                "Auto subordinate id range for {name} differs between subuid and subgid. \
+                 Using the subuid range for both."
+            );
+        }
+        u.or(g)
+    }
+}
+
+/// In-memory representation of `/etc/subuid` or `/etc/subgid`.
+///
+/// Unlike the passwd/group databases an owner may legitimately have multiple entries, so this is
+/// keyed by name to a list of ranges rather than a flat map.
+///
+/// Existing entries for owners not present in the config are preserved so that subordinate id
+/// ranges can never be reassigned to a different owner across generations. This mirrors how
+/// Userborn treats UIDs and GIDs.
+#[derive(Default)]
+pub struct SubId {
+    entries: BTreeMap<String, Vec<Range>>,
+}
+
+impl SubId {
+    /// Render the database in a stable order: by lowest start, then by name.
+    ///
+    /// This keeps the file byte-identical across runs as long as the set of ranges is unchanged,
+    /// regardless of config iteration order.
+    pub fn to_buffer(&self) -> String {
+        let mut owners: Vec<_> = self.entries.iter().collect();
+        owners.sort_by(|(an, ar), (bn, br)| {
+            let amin = ar.iter().map(|r| r.start).min().unwrap_or(u64::MAX);
+            let bmin = br.iter().map(|r| r.start).min().unwrap_or(u64::MAX);
+            amin.cmp(&bmin).then_with(|| an.cmp(bn))
+        });
+
+        let mut out = String::new();
+        for (name, ranges) in owners {
+            let mut ranges = ranges.clone();
+            ranges.sort_by_key(|r| r.start);
+            for r in ranges {
+                let _ = writeln!(out, "{name}:{}:{}", r.start, r.count);
+            }
+        }
+        out
+    }
+
+    pub fn ranges(&self, name: &str) -> &[Range] {
+        self.entries.get(name).map_or(&[], Vec::as_slice)
+    }
+
+    /// Replace all ranges for `name`.
+    pub fn set(&mut self, name: &str, ranges: Vec<Range>) {
+        if ranges.is_empty() {
+            self.entries.remove(name);
+        } else {
+            self.entries.insert(name.to_owned(), ranges);
+        }
+    }
+
+    /// Find an existing auto-style range (one with exactly the expected count) for `name`.
+    pub fn auto_range(&self, name: &str, count: u64) -> Option<Range> {
+        self.ranges(name).iter().find(|r| r.count == count).copied()
+    }
+
+    /// All `(owner, range)` pairs across the database.
+    pub fn entries(&self) -> impl Iterator<Item = EntryRef<'_>> {
+        self.entries
+            .iter()
+            .flat_map(|(name, ranges)| ranges.iter().map(move |r| EntryRef { name, range: *r }))
+    }
+}
+
+impl FromBuffer for SubId {
+    fn from_buffer(s: &str) -> Self {
+        let mut entries: BTreeMap<String, Vec<Range>> = BTreeMap::new();
+        for line in s.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Some((name, range)) = parse_line(line) {
+                entries.entry(name.to_owned()).or_default().push(range);
+            } else {
+                log::warn!("Skipping subid line because it cannot be parsed: {line}.");
+            }
+        }
+        Self { entries }
+    }
+}
+
+/// Allocate a `count`-wide range at or above `base` that does not overlap any of `occupied`.
+///
+/// `occupied` must be sorted by `start`. Duplicate entries are harmless.
+pub fn allocate(base: u64, count: u64, occupied: &[Range]) -> Result<Range> {
+    debug_assert!(occupied.is_sorted_by_key(|r| r.start));
+
+    let mut start = base;
+    for r in occupied {
+        if r.start >= start.saturating_add(count) {
+            // This and all later entries start after our probe ends.
+            break;
+        }
+        if (Range { start, count }).overlaps(*r) {
+            start = r.end();
+        }
+    }
+    if start.checked_add(count).is_none_or(|end| end > SUBID_MAX) {
+        bail!("No free {count}-wide subordinate id range available above {base}");
+    }
+    Ok(Range { start, count })
+}
+
+/// Returns the first pair of ranges that overlap across distinct owners, if any.
+///
+/// Ranges belonging to the same owner are allowed to overlap.
+pub fn find_overlap<'a>(entries: &[EntryRef<'a>]) -> Option<(EntryRef<'a>, EntryRef<'a>)> {
+    for (i, a) in entries.iter().enumerate() {
+        for b in &entries[i + 1..] {
+            if a.name != b.name && a.range.overlaps(b.range) {
+                return Some((*a, *b));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use expect_test::expect;
+    use indoc::indoc;
+
+    fn range(start: u64, count: u64) -> Range {
+        Range { start, count }
+    }
+
+    fn entry(name: &str, start: u64, count: u64) -> EntryRef<'_> {
+        EntryRef {
+            name,
+            range: range(start, count),
+        }
+    }
+
+    #[test]
+    fn parse_roundtrip() {
+        let buffer = indoc! {"
+            alice:100000:65536
+            bob:165536:65536
+        "};
+        let db = SubId::from_buffer(buffer);
+        assert_eq!(
+            db.ranges("alice"),
+            &[Range {
+                start: 100_000,
+                count: 65536
+            }]
+        );
+        let expected = expect![[r"
+            alice:100000:65536
+            bob:165536:65536
+        "]];
+        expected.assert_eq(&db.to_buffer());
+    }
+
+    #[test]
+    fn skip_comments_and_broken_lines() {
+        let buffer = indoc! {"
+            # comment
+
+            bad line
+            alice:100000:65536
+        "};
+        let db = SubId::from_buffer(buffer);
+        let expected = expect![[r"
+            alice:100000:65536
+        "]];
+        expected.assert_eq(&db.to_buffer());
+    }
+
+    #[test]
+    fn allocate_skips_occupied() {
+        // A huge root range as commonly configured for incus.
+        let occ = [range(1_000_000, 1_000_000_000)];
+        let r = allocate(100_000, 65536, &occ);
+        assert_eq!(r.ok().map(|r| r.start), Some(100_000));
+        // Base inside the huge root range -> jumps past it.
+        let r = allocate(2_000_000, 65536, &occ);
+        assert_eq!(r.ok().map(|r| r.start), Some(1_001_000_000));
+    }
+
+    #[test]
+    fn allocate_packs_after_existing() {
+        let occ = [range(100_000, 65536), range(165_536, 65536)];
+        let r = allocate(100_000, 65536, &occ);
+        assert_eq!(r.ok().map(|r| r.start), Some(231_072));
+    }
+
+    #[test]
+    fn allocate_with_base_past_early_entries() {
+        // The early-exit must not fire on the first (already-past) entry,
+        // because the second one still overlaps the base.
+        let occ = [range(100_000, 65536), range(900_000, 200_000)];
+        let r = allocate(1_000_000, 65536, &occ);
+        assert_eq!(r.ok().map(|r| r.start), Some(1_100_000));
+    }
+
+    #[test]
+    fn allocate_exhausted() {
+        let occ = [range(0, SUBID_MAX)];
+        assert!(allocate(100_000, 65536, &occ).is_err());
+    }
+
+    #[test]
+    fn overlap_detected() {
+        let occ = [entry("a", 100_000, 65536), entry("b", 100_100, 65536)];
+        assert!(find_overlap(&occ).is_some());
+    }
+
+    #[test]
+    fn overlap_same_owner_ignored() {
+        let occ = [entry("a", 100_000, 65536), entry("a", 100_100, 65536)];
+        assert!(find_overlap(&occ).is_none());
+    }
+}

--- a/rust/userborn/src/subid.rs
+++ b/rust/userborn/src/subid.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, fmt::Write as _};
 
 use anyhow::{Result, bail};
+use serde::Deserialize;
 
 use crate::FromBuffer;
 
@@ -10,10 +11,22 @@ use crate::FromBuffer;
 /// various userspace tools, so the auto allocator never hands out a range that extends past it.
 const SUBID_MAX: u64 = 0x8000_0000;
 
+/// Lowest id at which automatically allocated subordinate id ranges start.
+///
+/// Matches shadow's `SUB_UID_MIN` default in `login.defs`.
+pub const AUTO_BASE: u64 = 100_000;
+
+/// Width of an automatically allocated subordinate id range.
+///
+/// Matches shadow's `SUB_UID_COUNT` default in `login.defs`.
+pub const AUTO_COUNT: u64 = 65_536;
+
 /// A half-open subordinate id interval `[start, start + count)`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Range {
+    /// First id in the range.
     pub start: u64,
+    /// Number of consecutive ids in the range.
     pub count: u64,
 }
 
@@ -64,9 +77,9 @@ impl SubIds {
     /// --add-subgids`. Looking in both lets us restore a range that survived in only one
     /// file instead of allocating a fresh one and breaking existing containers. If both are
     /// present but disagree we warn and prefer `subuid`.
-    pub fn auto_range(&self, name: &str, count: u64) -> Option<Range> {
-        let u = self.uid.auto_range(name, count);
-        let g = self.gid.auto_range(name, count);
+    pub fn auto_range(&self, name: &str) -> Option<Range> {
+        let u = self.uid.auto_range(name);
+        let g = self.gid.auto_range(name);
         if u.is_some() && g.is_some() && u != g {
             log::warn!(
                 "Auto subordinate id range for {name} differs between subuid and subgid. \
@@ -127,9 +140,12 @@ impl SubId {
         }
     }
 
-    /// Find an existing auto-style range (one with exactly the expected count) for `name`.
-    pub fn auto_range(&self, name: &str, count: u64) -> Option<Range> {
-        self.ranges(name).iter().find(|r| r.count == count).copied()
+    /// Find an existing auto-style range (one with exactly [`AUTO_COUNT`] width) for `name`.
+    pub fn auto_range(&self, name: &str) -> Option<Range> {
+        self.ranges(name)
+            .iter()
+            .find(|r| r.count == AUTO_COUNT)
+            .copied()
     }
 
     /// All `(owner, range)` pairs across the database.


### PR DESCRIPTION
Subordinate id ranges have the same reuse risk as normal user ids: files
created by a user's unprivileged containers are owned by ids in their
range, so reassigning the range to another user grants access to those
files.

We cannot precompute suitable ranges outside of userborn because we need
to take into account existing ranges, and with only 31 bits of usable id
space, assigning a static range to each user can quickly run out of space
(especially with some tools like incus assigning massive ranges by
default).

So we treat sub{u,g}id in the same way as normal {u,g}ids: read the
existing file, allocate non-overlapping ranges for users that need one,
and never remove entries.

This is one of the missing pieces for making userborn the default
user/group management tool in NixOS, where the perl activation script
currently handles `users.users.<name>.subUidRanges` / `subGidRanges` and
`autoSubUidGidRange`.

Closes #7

CC: @nikstur 
