### PR TITLE
treewide: keep file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Removed the ability to configure the path to the `nologin` binary during
   runtime via the env variable `USERBORN_NO_LOGIN_PATH`. Instead, configure the
   path during compilation of Userborn via `USERBORN_NO_LOGIN_DEFAULT_PATH`.
+- The file mode, uid, and gid of /etc/{group,passwd,shadow} are now retained if
+  the files already exist. If the files don't exist, they are created with the
+  same permissions as before. This enables setups where `/etc/shadow` is owned
+  by the `shadow` group with mode `640` and `unix_chkpwd` only has the `setgid`
+  bit. Most notably, this is the default on Debian/Ubuntu derivatives.
 
 ## 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ services.userborn.enable = true;
 - Never deletes a user or group, only disables them when they are not present
   in the config anymore.
 - Never changes the UID of an existing user or the GID of an existing group.
+- The file mode, uid, and gid of the `/etc/{group,passwd,shadow}` files is
+  never changed. If the files already exist before Userborn runs for the first
+  time it will retain these values.
 
 This prohibits UID/GID re-use which is a security issue. The danger of UID/GID
 re-use is best illustrated by an example. Imagine the following scenario:

--- a/rust/userborn/src/fs.rs
+++ b/rust/userborn/src/fs.rs
@@ -1,6 +1,58 @@
-use std::{fs, io::Write, os::unix::fs::OpenOptionsExt, path::Path};
+use std::{
+    fs,
+    io::{Read, Write},
+    os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt, chown},
+    path::Path,
+};
 
 use anyhow::{Context, Result};
+
+pub struct Rights {
+    mode: u32,
+    ownership: Option<Ownership>,
+}
+
+struct Ownership {
+    uid: u32,
+    gid: u32,
+}
+
+impl Rights {
+    pub fn from_mode(mode: u32) -> Self {
+        Self {
+            mode,
+            ownership: None,
+        }
+    }
+}
+
+/// Read a file to a string.
+///
+/// Returns the rights (mode, permissions) of this file.
+///
+/// This can then later be used to write the file with the same rights it used to have.
+pub fn read_to_string(path: impl AsRef<Path>) -> Result<(String, Rights)> {
+    let mut file = fs::File::open(path.as_ref())
+        .with_context(|| format!("Failed to read {}.", path.as_ref().display()))?;
+
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("Failed to read metadata from {}.", path.as_ref().display()))?;
+    let rights = Rights {
+        mode: metadata.permissions().mode(),
+        ownership: Some(Ownership {
+            uid: metadata.uid(),
+            gid: metadata.gid(),
+        }),
+    };
+
+    let mut buf = String::new();
+    let _ = file
+        .read_to_string(&mut buf)
+        .with_context(|| format!("Failed to read string from {}.", path.as_ref().display()))?;
+
+    Ok((buf, rights))
+}
 
 /// Atomically write a buffer into a file.
 ///
@@ -8,7 +60,11 @@ use anyhow::{Context, Result};
 /// its actual path.
 ///
 /// This increases the atomicity of the write.
-pub fn atomic_write(path: impl AsRef<Path>, buffer: impl AsRef<[u8]>, mode: u32) -> Result<()> {
+pub fn atomic_write(
+    path: impl AsRef<Path>,
+    buffer: impl AsRef<[u8]>,
+    rights: &Rights,
+) -> Result<()> {
     let mut i = 0;
 
     let (mut file, tmp_path) = loop {
@@ -19,7 +75,7 @@ pub fn atomic_write(path: impl AsRef<Path>, buffer: impl AsRef<[u8]>, mode: u32)
             .write(true)
             .create_new(true)
             .truncate(true)
-            .mode(mode)
+            .mode(rights.mode)
             .open(&tmp_path);
         match res {
             Ok(file) => break (file, tmp_path),
@@ -35,6 +91,11 @@ pub fn atomic_write(path: impl AsRef<Path>, buffer: impl AsRef<[u8]>, mode: u32)
         i += 1;
     };
 
+    if let Some(ref ownership) = rights.ownership {
+        chown(&tmp_path, Some(ownership.uid), Some(ownership.gid)).with_context(|| {
+            format!("Failed to chmod the temporary file {}", tmp_path.display())
+        })?;
+    }
     file.write_all(buffer.as_ref())
         .with_context(|| format!("Failed to write to {}", tmp_path.display()))?;
     file.sync_all()

--- a/rust/userborn/src/group.rs
+++ b/rust/userborn/src/group.rs
@@ -1,12 +1,8 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fs,
-    path::Path,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 
-use crate::{fs::atomic_write, id};
+use crate::{FromBuffer, id};
 
 #[derive(Clone)]
 pub struct Entry {
@@ -101,31 +97,6 @@ pub struct Group {
 }
 
 impl Group {
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
-        let file = fs::read_to_string(path.as_ref())
-            .with_context(|| format!("Failed to read {}.", path.as_ref().display()))?;
-
-        Ok(Self::from_buffer(&file))
-    }
-
-    fn from_buffer(s: &str) -> Self {
-        let mut entries = BTreeMap::new();
-        let mut gids = BTreeMap::new();
-        for line in s.lines() {
-            if let Some(e) = Entry::from_line(line) {
-                entries.insert(e.gid, e.clone());
-                gids.insert(e.name.clone(), e.gid);
-            } else {
-                log::warn!("Skipping group line because it cannot be parsed: {line}.");
-            }
-        }
-        Self { entries, gids }
-    }
-
-    pub fn to_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer(), 0o644)
-    }
-
     pub fn to_buffer(&self) -> String {
         let mut s = String::new();
         for entry in self.entries.values() {
@@ -174,6 +145,22 @@ impl Group {
 
     pub fn entries_mut(&mut self) -> impl IntoIterator<Item = &mut Entry> {
         self.entries.values_mut()
+    }
+}
+
+impl FromBuffer for Group {
+    fn from_buffer(s: &str) -> Self {
+        let mut entries = BTreeMap::new();
+        let mut gids = BTreeMap::new();
+        for line in s.lines() {
+            if let Some(e) = Entry::from_line(line) {
+                entries.insert(e.gid, e.clone());
+                gids.insert(e.name.clone(), e.gid);
+            } else {
+                log::warn!("Skipping group line because it cannot be parsed: {line}.");
+            }
+        }
+        Self { entries, gids }
     }
 }
 

--- a/rust/userborn/src/main.rs
+++ b/rust/userborn/src/main.rs
@@ -6,16 +6,35 @@ mod passwd;
 mod password;
 mod shadow;
 
-use std::{collections::BTreeSet, io::Write, process::ExitCode};
+use std::{collections::BTreeSet, io::Write, path::Path, process::ExitCode};
 
 use anyhow::{Context, Result, anyhow};
 use log::{Level, LevelFilter};
 
 use config::Config;
+use fs::{Rights, atomic_write, read_to_string};
 use group::Group;
 use passwd::Passwd;
 use password::HashedPassword;
 use shadow::Shadow;
+
+trait FromBuffer {
+    fn from_buffer(buf: &str) -> Self;
+}
+
+/// Read a file and its rights.
+///
+/// If the file doesn't exist, return the default representation of T alongside the rights with a
+/// provided default mode.
+fn read_or_default<T>(path: impl AsRef<Path>, default_mode: u32) -> (T, Rights)
+where
+    T: FromBuffer + Default,
+{
+    match read_to_string(path) {
+        Ok((buf, rights)) => (T::from_buffer(&buf), rights),
+        Err(_) => (T::default(), Rights::from_mode(default_mode)),
+    }
+}
 
 /// Fallback path to the nologin binary.
 ///
@@ -90,9 +109,9 @@ fn run() -> Result<()> {
     let passwd_path = format!("{directory}/passwd");
     let shadow_path = format!("{directory}/shadow");
 
-    let mut group_db = Group::from_file(&group_path).unwrap_or_default();
-    let mut passwd_db = Passwd::from_file(&passwd_path).unwrap_or_default();
-    let mut shadow_db = Shadow::from_file(&shadow_path).unwrap_or_default();
+    let (mut group_db, group_rights) = read_or_default::<Group>(&group_path, 0o644);
+    let (mut passwd_db, passwd_rights) = read_or_default::<Passwd>(&passwd_path, 0o644);
+    let (mut shadow_db, shadow_rights) = read_or_default::<Shadow>(&shadow_path, 0o000);
 
     update_users_and_groups(
         &config,
@@ -107,9 +126,13 @@ fn run() -> Result<()> {
     log::debug!("Persisting files to disk...");
     // We should skip this if the files haven't actually changed
     // We should create backup files with an `-` appended to the filename.
-    group_db.to_file(group_path)?;
-    passwd_db.to_file(passwd_path)?;
-    shadow_db.to_file_sorted(&passwd_db, shadow_path)?;
+    atomic_write(group_path, group_db.to_buffer(), &group_rights)?;
+    atomic_write(passwd_path, passwd_db.to_buffer(), &passwd_rights)?;
+    atomic_write(
+        shadow_path,
+        shadow_db.to_buffer_sorted(&passwd_db),
+        &shadow_rights,
+    )?;
 
     Ok(())
 }

--- a/rust/userborn/src/passwd.rs
+++ b/rust/userborn/src/passwd.rs
@@ -1,12 +1,8 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fs,
-    path::Path,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 
-use crate::{fs::atomic_write, id};
+use crate::{FromBuffer, id};
 
 /// Password for /etc/passwd indicating that the actual password is stored in /etc/shadow.
 const PASSWORD_IN_SHADOW: &str = "x";
@@ -147,31 +143,6 @@ pub struct Passwd {
 }
 
 impl Passwd {
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
-        let file = fs::read_to_string(path.as_ref())
-            .with_context(|| format!("Failed to read {}.", path.as_ref().display()))?;
-
-        Ok(Self::from_buffer(&file))
-    }
-
-    pub fn from_buffer(s: &str) -> Self {
-        let mut entries = BTreeMap::new();
-        let mut uids = BTreeMap::new();
-        for line in s.lines() {
-            if let Some(e) = Entry::from_line(line) {
-                entries.insert(e.uid, e.clone());
-                uids.insert(e.name.clone(), e.uid);
-            } else {
-                log::warn!("Skipping passwd line because it cannot be parsed: {line}.");
-            }
-        }
-        Self { entries, uids }
-    }
-
-    pub fn to_file(&self, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer(), 0o644)
-    }
-
     pub fn to_buffer(&self) -> String {
         let mut s = String::new();
         for entry in self.entries.values() {
@@ -214,6 +185,22 @@ impl Passwd {
 
     pub fn entries(&self) -> Vec<&Entry> {
         self.entries.values().collect()
+    }
+}
+
+impl FromBuffer for Passwd {
+    fn from_buffer(s: &str) -> Self {
+        let mut entries = BTreeMap::new();
+        let mut uids = BTreeMap::new();
+        for line in s.lines() {
+            if let Some(e) = Entry::from_line(line) {
+                entries.insert(e.uid, e.clone());
+                uids.insert(e.name.clone(), e.uid);
+            } else {
+                log::warn!("Skipping passwd line because it cannot be parsed: {line}.");
+            }
+        }
+        Self { entries, uids }
     }
 }
 

--- a/rust/userborn/src/shadow.rs
+++ b/rust/userborn/src/shadow.rs
@@ -1,8 +1,8 @@
-use std::{collections::BTreeMap, fs, path::Path};
+use std::collections::BTreeMap;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 
-use crate::{fs::atomic_write, passwd::Passwd};
+use crate::{FromBuffer, passwd::Passwd};
 
 /// A locked and invalid password.
 const PASSWORD_LOCKED_AND_INVALID: &str = "!*";
@@ -109,32 +109,6 @@ impl Entry {
 pub struct Shadow(BTreeMap<String, Entry>);
 
 impl Shadow {
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
-        let file = fs::read_to_string(path.as_ref())
-            .with_context(|| format!("Failed to read {}.", path.as_ref().display()))?;
-
-        Ok(Self::from_buffer(&file))
-    }
-
-    fn from_buffer(s: &str) -> Self {
-        let mut entries = BTreeMap::new();
-        for line in s.lines() {
-            if let Some(e) = Entry::from_line(line) {
-                entries.insert(e.name.clone(), e.clone());
-            } else {
-                log::warn!("Skipping shadow line because it cannot be parsed: {line}.");
-            }
-        }
-        Self(entries)
-    }
-
-    /// Write the shadow database to a file.
-    ///
-    /// Sort the entries by their UIDs in the passwd database.
-    pub fn to_file_sorted(&self, passwd: &Passwd, path: impl AsRef<Path>) -> Result<()> {
-        atomic_write(path, self.to_buffer_sorted(passwd), 0o000)
-    }
-
     /// Write the shadow database to a string buffer.
     ///
     /// Sort the entries by their UIDs in the passwd database.
@@ -179,6 +153,20 @@ impl Shadow {
 
     pub fn entries_mut(&mut self) -> impl IntoIterator<Item = &mut Entry> {
         self.0.values_mut()
+    }
+}
+
+impl FromBuffer for Shadow {
+    fn from_buffer(s: &str) -> Self {
+        let mut entries = BTreeMap::new();
+        for line in s.lines() {
+            if let Some(e) = Entry::from_line(line) {
+                entries.insert(e.name.clone(), e.clone());
+            } else {
+                log::warn!("Skipping shadow line because it cannot be parsed: {line}.");
+            }
+        }
+        Self(entries)
     }
 }
 


### PR DESCRIPTION
Userborn now keeps the file uid, gid, and file permissions of the files it writes. If the files don't already exist, they are created with the same permissions as before.

Supersedes #41 and #46